### PR TITLE
Add defrost status binary sensor for AC appliances

### DIFF
--- a/custom_components/hon/binary_sensor.py
+++ b/custom_components/hon/binary_sensor.py
@@ -208,6 +208,12 @@ BINARY_SENSORS: dict[str, tuple[HonBinarySensorEntityDescription, ...]] = {
             name="Ch2O Cleaning",
             on_value=1,
         ),
+        HonBinarySensorEntityDescription(
+            key="defrostStatus",
+            name="Defrost Status",
+            icon="mdi:snowflake-melt",
+            on_value=1,
+        ),
     ),
     "REF": (
         HonBinarySensorEntityDescription(


### PR DESCRIPTION
Add a new binary sensor to monitor the defrost status of air conditioning units. The sensor uses the 'defrostStatus' key and displays when the AC is in defrost mode with a snowflake-melt icon.