### PR TITLE
Add Preheat Binary Sensor for Ovens + Fix Attribute Handling for Binary Sensors

### DIFF
--- a/custom_components/hon/binary_sensor.py
+++ b/custom_components/hon/binary_sensor.py
@@ -123,6 +123,14 @@ BINARY_SENSORS: dict[str, tuple[HonBinarySensorEntityDescription, ...]] = {
             icon="mdi:power-cycle",
             translation_key="on",
         ),
+        HonBinarySensorEntityDescription(
+            key="attributes.parameters.preheatStatus",
+            name="Pre-Heat",
+            device_class=BinarySensorDeviceClass.RUNNING,
+            on_value=1,
+            icon="mdi:thermometer-chevron-up",
+            translation_key="pre_heat",
+        ),
     ),
     "IH": (
         HonBinarySensorEntityDescription(
@@ -245,8 +253,8 @@ BINARY_SENSORS: dict[str, tuple[HonBinarySensorEntityDescription, ...]] = {
         HonBinarySensorEntityDescription(
             key="doorStatusZ2",
             name="Door1 Status Freezer",
-            icon="mdi:fridge-bottom",
             device_class=BinarySensorDeviceClass.DOOR,
+            icon="mdi:fridge-bottom",
             on_value=1,
             translation_key="freezer_door",
         ),
@@ -334,16 +342,15 @@ class HonBinarySensorEntity(HonEntity, BinarySensorEntity):
 
     @property
     def is_on(self) -> bool:
-        return bool(
-            self._device.get(self.entity_description.key, "")
-            == self.entity_description.on_value
-        )
+        attr = self._device.get(self.entity_description.key, None)
+        value = attr.value if hasattr(attr, "value") else attr
+        return value == self.entity_description.on_value
 
     @callback
     def _handle_coordinator_update(self, update: bool = True) -> None:
-        self._attr_native_value = (
-            self._device.get(self.entity_description.key, "")
-            == self.entity_description.on_value
-        )
+        attr = self._device.get(self.entity_description.key, None)
+        value = attr.value if hasattr(attr, "value") else attr
+        self._attr_native_value = (value == self.entity_description.on_value)
         if update:
             self.schedule_update_ha_state()
+


### PR DESCRIPTION
This PR introduces a new binary sensor for Haier ovens based on the preheatStatus attribute. While implementing this feature, I discovered that the integration does not correctly evaluate certain appliance attributes, which caused binary sensors to always report off even when the underlying value indicated they should be on.

Issue Identified

Attributes such as preheatStatus and onOffStatus are not returned as raw integers. Instead, the integration receives them as HonAttribute objects. Because the existing logic compares the object itself directly against the expected value, the expression value == on_value always evaluates to False.

Fix Implemented

To ensure proper evaluation, the binary sensor logic has been updated so that when an attribute is a HonAttribute instance, the sensor extracts its actual value using:

value = attr.value if hasattr(attr, "value") else attr


This fix has been applied to both:

is_on()

_handle_coordinator_update()

As a result, the newly added preheatStatus sensor works correctly, and the previously existing onOffStatus binary sensor now functions reliably as well.

Potential Impact on Other Sensors

This change may also correct the behavior of other binary sensors that rely on attributes following the same pattern. I cannot verify all of them because I only have access to a single Haier oven, but the patch is safe, backward-compatible, and should improve the accuracy of any affected entities.