### PR TITLE
feat(WM): add remaining wash time, detergent level, cycle counter and status sensors

### DIFF
--- a/custom_components/hon/binary_sensor.py
+++ b/custom_components/hon/binary_sensor.py
@@ -83,6 +83,28 @@ BINARY_SENSORS: dict[str, tuple[HonBinarySensorEntityDescription, ...]] = {
             name="Acqua Plus",
             translation_key="acqua_plus",
         ),
+        HonBinarySensorEntityDescription(
+            key="energySavingStatus",
+            name="Energy Saving Mode",
+            on_value=1,
+            icon="mdi:leaf",
+            translation_key="energy_saving",
+        ),
+        HonBinarySensorEntityDescription(
+            key="buzzerDisabled",
+            name="Buzzer Disabled",
+            on_value=1,
+            icon="mdi:volume-off",
+            translation_key="buzzer_disabled",
+        ),
+        HonBinarySensorEntityDescription(
+            key="lockStatus",
+            name="Child Lock",
+            device_class=BinarySensorDeviceClass.LOCK,
+            on_value=0,
+            icon="mdi:lock",
+            translation_key="child_lock",
+        ),
     ),
     "TD": (
         HonBinarySensorEntityDescription(

--- a/custom_components/hon/sensor.py
+++ b/custom_components/hon/sensor.py
@@ -204,6 +204,29 @@ SENSORS: dict[str, tuple[SensorEntityDescription, ...]] = {
             translation_key="stain_type",
             option_list=const.STAIN_TYPES,
         ),
+        HonSensorEntityDescription(
+            key="remainingMainWashTime",
+            name="Remaining Main Wash Time",
+            icon="mdi:timer-sand",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=UnitOfTime.MINUTES,
+            translation_key="remaining_main_wash_time",
+        ),
+        HonSensorEntityDescription(
+            key="currentWashCycle",
+            name="Current Wash Cycle",
+            icon="mdi:counter",
+            state_class=SensorStateClass.MEASUREMENT,
+            translation_key="current_wash_cycle",
+        ),
+        HonSensorEntityDescription(
+            key="detergentPercent",
+            name="Detergent Level",
+            icon="mdi:cup-water",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=PERCENTAGE,
+            translation_key="detergent_level",
+        ),
     ),
     "TD": (
         HonSensorEntityDescription(

--- a/custom_components/hon/translations/en.json
+++ b/custom_components/hon/translations/en.json
@@ -78,6 +78,15 @@
                 },
                 "name": "Drying level"
             },
+            "remaining_main_wash_time": {
+                "name": "Remaining Main Wash Time"
+            },
+            "current_wash_cycle": {
+                "name": "Current Wash Cycle"
+            },
+            "detergent_level": {
+                "name": "Detergent Level"
+            },
             "programs_ac": {
                 "state": {
                     "iot_10_heating": "10°C Heating function",
@@ -2068,6 +2077,12 @@
             },
             "filter_replacement": {
                 "name": "Filter replacement"
+            },
+            "energy_saving": {
+                "name": "Energy Saving Mode"
+            },
+            "buzzer_disabled": {
+                "name": "Buzzer Disabled"
             }
         },
         "button": {

--- a/custom_components/hon/translations/pt.json
+++ b/custom_components/hon/translations/pt.json
@@ -70,6 +70,15 @@
                 },
                 "name": "Nível de secagem"
             },
+            "remaining_main_wash_time": {
+                "name": "Tempo Restante da Lavagem Principal"
+            },
+            "current_wash_cycle": {
+                "name": "Ciclo de Lavagem Atual"
+            },
+            "detergent_level": {
+                "name": "Nível de Detergente"
+            },
             "programs_ac": {
                 "state": {
                     "iot_10_heating": "Função de aquecimento de 10 °C",
@@ -2015,6 +2024,12 @@
             },
             "filter_replacement": {
                 "name": "Substituição do filtro"
+            },
+            "energy_saving": {
+                "name": "Modo Poupança de Energia"
+            },
+            "buzzer_disabled": {
+                "name": "Buzzer Desativado"
             }
         },
         "button": {


### PR DESCRIPTION
## Summary

This PR extends the washing machine (`WM`) appliance support with new entities based on data available in the hOn API but not yet exposed in the integration.

All added entities have been validated against real device API dumps from a **Haier HW120-B14979EUGS** washing machine running firmware `5.30.0`.

***

## New Entities

### `sensor`
- `remainingMainWashTime` — Remaining Main Wash Time (unit: min, state_class: measurement)
- `currentWashCycle` — Current Wash Cycle (state_class: measurement)
- `detergentPercent` — Detergent Level (unit: %, state_class: measurement)

### `binary_sensor`
- `energySavingStatus` — Energy Saving Mode (on_value: 1)
- `buzzerDisabled` — Buzzer Disabled (on_value: 1)
- `lockStatus` — Child Lock (device_class: lock, on_value: 0)

***

## Files Changed

- `custom_components/hon/sensor.py` — added 3 entries to `SENSORS["WM"]`
- `custom_components/hon/binary_sensor.py` — added 3 entries to `BINARY_SENSORS["WM"]`
- `custom_components/hon/translations/en.json` — added translation keys
- `custom_components/hon/translations/pt.json` — added Portuguese translations

***

## How to Test

1. Install the integration with a compatible Haier/Candy/Hoover washing machine
2. Restart Home Assistant
3. Navigate to **Settings → Devices & Services → hOn → [your washing machine]**
4. Start a wash cycle and confirm the new entities update correctly

> Note: `detergentPercent` is only meaningful on models with AutoDose detergent dispensing (e.g. Haier 979 series). On other models it will remain at `100`.

***

## Related

- Validated against API dump data — no changes to `pyhon` dependency required
- Follows existing patterns from `OV` and `DW` appliance implementations