### PR TITLE
Bump pyhon-revived to 0.18.4 (fix login / empty appliance list)

### DIFF
--- a/custom_components/hon/manifest.json
+++ b/custom_components/hon/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/mmalolepszy/hon-revived/issues",
   "requirements": [
-    "pyhon-revived==0.18.3"
+    "pyhon-revived==0.18.4"
   ],
   "version": "0.18.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyhon-revived==0.18.3
+pyhon-revived==0.18.4


### PR DESCRIPTION
## Summary

Haier retired the legacy Salesforce login, which made the integration set up successfully but discover **no devices** (the old appliance-list endpoint now returns an empty list).

The fix lives in the `pyhon-revived` library (CIAM/PKCE login + new appliance-list endpoint). This PR bumps the integration to the fixed release.

## Changes

- `requirements.txt`: `pyhon-revived==0.18.3` → `==0.18.4`
- `custom_components/hon/manifest.json`: same dependency bump

## Test plan

- [ ] Fresh install / reload of the integration discovers appliances again
- [ ] Existing entities update and commands work

Depends on mmalolepszy/pyhon-revived#7 (must be merged and released to PyPI as `0.18.4` first).

Closes #44