### PR TITLE
fix; Fix typo in air conditioner temperature target text, issue: 59

### DIFF
--- a/custom_components/hon/translations/it.json
+++ b/custom_components/hon/translations/it.json
@@ -839,7 +839,7 @@
                 "name": "Durata"
             },
             "target_temperature": {
-                "name": "Temperatura terget"
+                "name": "Temperature target"
             },
             "spin_speed": {
                 "name": "Centrifuga"
@@ -2058,7 +2058,7 @@
                 "name": "Durata programma"
             },
             "target_temperature": {
-                "name": "Temperatura terget"
+                "name": "Temperature target"
             },
             "rinse_iterations": {
                 "name": "Numero risciacqui"


### PR DESCRIPTION
## Summary

Fixes a typo in the air conditioner temperature target text.

Changed:

Temperatura terget

to

Temperature target

Fixes #59